### PR TITLE
XHRStreamingSession detached requests that had seen more than

### DIFF
--- a/txdarn/test/test_protocol.py
+++ b/txdarn/test/test_protocol.py
@@ -1522,17 +1522,17 @@ class XHRStreamingSessionTestCase(RequestSessionProtocolWrapperTestCase):
                                                 b'o\n'])
         self.assertEqual(self.sessionMachineRecorder.detachCalls, 0)
 
-    def test_writeData(self):
+    def test_completeWrite(self):
         '''XHRStreamingSession detaches the request after writing at least
         maximumBytes.
 
         '''
         self.protocol.request = self.request
 
-        self.protocol.writeData(['ignored'])
+        self.protocol.completeWrite(['ignored'])
         self.assertEqual(self.sessionMachineRecorder.detachCalls, 0)
 
-        self.protocol.writeData(['ignored' * self.maximumBytes])
+        self.protocol.completeWrite(['ignored' * self.maximumBytes])
         self.assertEqual(self.sessionMachineRecorder.detachCalls, 1)
 
 


### PR DESCRIPTION
maximumBytes via writeData.  by overriding this method, the session
state machine XHRStreamingSession wasn't letting the session
machine buffer writes when the request was detached.

the solution was to override completeWrite instead.
